### PR TITLE
Added Android base classes so that effect & state emissions are on main scheduler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,9 +46,10 @@ buildscript {
         ],
 
         'rx1'    : [
-            'java'  : 'io.reactivex:rxjava:1.3.8',
-            'kotlin': 'io.reactivex:rxkotlin:1.0.0',
-            'relay' : 'com.jakewharton.rxrelay:rxrelay:1.2.0'
+            'java'   : 'io.reactivex:rxjava:1.3.8',
+            'kotlin' : 'io.reactivex:rxkotlin:1.0.0',
+            'android': 'io.reactivex:rxandroid:1.2.1',
+            'relay'  : 'com.jakewharton.rxrelay:rxrelay:1.2.0'
         ],
 
         'rx2'    : [
@@ -90,7 +91,7 @@ task clean(type: Delete) {
 subprojects {
     group = "com.gyurigrell"
     def isRelease = Boolean.valueOf(project.hasProperty("release") ? project.property("release") as String : "false")
-    version = "0.3.1" + (isRelease ? "" : "-SNAPSHOT")
+    version = "0.3.2" + (isRelease ? "" : "-SNAPSHOT")
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
         kotlinOptions {

--- a/rxreactor1-android/build.gradle
+++ b/rxreactor1-android/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation deps.kotlin.stdlib.jdk
     implementation deps.support.appcompat
     implementation deps.support.fragment
+    implementation deps.rx1.android
 
     testImplementation deps.junit
 

--- a/rxreactor1-android/src/main/java/com/gyurigrell/rxreactor1/android/AndroidReactor.kt
+++ b/rxreactor1-android/src/main/java/com/gyurigrell/rxreactor1/android/AndroidReactor.kt
@@ -8,5 +8,5 @@ import rx.android.schedulers.AndroidSchedulers
  * Specialized implementation of [Reactor] that ensures [state] Observables emits on [AndroidSchedulers.mainThread]
  */
 class AndroidReactor<Action, Mutation, State>(initialState: State): Reactor<Action, Mutation, State>(initialState) {
-    override fun transformAction(action: Observable<Action>): Observable<Action> = action.observeOn(AndroidSchedulers.mainThread())
+    override fun transformState(state: Observable<State>): Observable<State> = state.observeOn(AndroidSchedulers.mainThread())
 }

--- a/rxreactor1-android/src/main/java/com/gyurigrell/rxreactor1/android/AndroidReactor.kt
+++ b/rxreactor1-android/src/main/java/com/gyurigrell/rxreactor1/android/AndroidReactor.kt
@@ -1,0 +1,12 @@
+package com.gyurigrell.rxreactor1.android
+
+import com.gyurigrell.rxreactor1.Reactor
+import rx.Observable
+import rx.android.schedulers.AndroidSchedulers
+
+/**
+ * Specialized implementation of [Reactor] that ensures [state] Observables emits on [AndroidSchedulers.mainThread]
+ */
+class AndroidReactor<Action, Mutation, State>(initialState: State): Reactor<Action, Mutation, State>(initialState) {
+    override fun transformAction(action: Observable<Action>): Observable<Action> = action.observeOn(AndroidSchedulers.mainThread())
+}

--- a/rxreactor1-android/src/main/java/com/gyurigrell/rxreactor1/android/AndroidReactorWithEffect.kt
+++ b/rxreactor1-android/src/main/java/com/gyurigrell/rxreactor1/android/AndroidReactorWithEffect.kt
@@ -1,0 +1,17 @@
+package com.gyurigrell.rxreactor1.android
+
+import com.gyurigrell.rxreactor1.ReactorWithEffects
+import rx.Observable
+import rx.android.schedulers.AndroidSchedulers
+
+/**
+ * Specialized implementation of [ReactorWithEffects] that ensures [effect] and [state] Observables emit on
+ * [AndroidSchedulers.mainThread]
+ */
+class AndroidReactorWithEffect<Action, Mutation : ReactorWithEffects.MutationWithEffect<Effect>, State, Effect>(
+    initialState: State
+) : ReactorWithEffects<Action, Mutation, State, Effect>(initialState) {
+    override fun transformEffect(effect: Observable<Effect>): Observable<Effect> = effect.observeOn(AndroidSchedulers.mainThread())
+
+    override fun transformAction(action: Observable<Action>): Observable<Action> = action.observeOn(AndroidSchedulers.mainThread())
+}

--- a/rxreactor1-android/src/main/java/com/gyurigrell/rxreactor1/android/AndroidReactorWithEffect.kt
+++ b/rxreactor1-android/src/main/java/com/gyurigrell/rxreactor1/android/AndroidReactorWithEffect.kt
@@ -13,5 +13,5 @@ class AndroidReactorWithEffect<Action, Mutation : ReactorWithEffects.MutationWit
 ) : ReactorWithEffects<Action, Mutation, State, Effect>(initialState) {
     override fun transformEffect(effect: Observable<Effect>): Observable<Effect> = effect.observeOn(AndroidSchedulers.mainThread())
 
-    override fun transformAction(action: Observable<Action>): Observable<Action> = action.observeOn(AndroidSchedulers.mainThread())
+    override fun transformState(state: Observable<State>): Observable<State> = state.observeOn(AndroidSchedulers.mainThread())
 }

--- a/rxreactor1-android/src/main/java/com/gyurigrell/rxreactor1/android/ReactorStoreFragment.kt
+++ b/rxreactor1-android/src/main/java/com/gyurigrell/rxreactor1/android/ReactorStoreFragment.kt
@@ -85,9 +85,9 @@ class ReactorStoreFragment @SuppressLint("ValidFragment") constructor(
             val parentFragment = holderFragment.parentFragment
             if (parentFragment != null) {
                 notCommittedFragmentHolders.remove(parentFragment)
-                parentFragment.fragmentManager?.unregisterFragmentLifecycleCallbacks(parentDestroyedCallback)
+                parentFragment.parentFragmentManager.unregisterFragmentLifecycleCallbacks(parentDestroyedCallback)
             } else {
-                notCommittedActivityHolders.remove(holderFragment.activity!!)
+                notCommittedActivityHolders.remove(holderFragment.requireActivity())
             }
         }
 
@@ -122,7 +122,7 @@ class ReactorStoreFragment @SuppressLint("ValidFragment") constructor(
                 return reactorStoreFragment
             }
 
-            parentFragment.fragmentManager?.registerFragmentLifecycleCallbacks(parentDestroyedCallback, false)
+            parentFragment.parentFragmentManager.registerFragmentLifecycleCallbacks(parentDestroyedCallback, false)
             reactorStoreFragment = createReactorStoreFragment(fm)
             notCommittedFragmentHolders[parentFragment] = reactorStoreFragment
             return reactorStoreFragment

--- a/rxreactor2-android/build.gradle
+++ b/rxreactor2-android/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation deps.kotlin.stdlib.jdk
     implementation deps.support.appcompat
     implementation deps.support.fragment
+    implementation deps.rx2.android
 
     testImplementation deps.junit
 

--- a/rxreactor2-android/src/main/java/com/gyurigrell/rxreactor2/android/AndroidReactor.kt
+++ b/rxreactor2-android/src/main/java/com/gyurigrell/rxreactor2/android/AndroidReactor.kt
@@ -1,0 +1,12 @@
+package com.gyurigrell.rxreactor2.android
+
+import com.gyurigrell.rxreactor2.Reactor
+import io.reactivex.Observable
+import io.reactivex.android.schedulers.AndroidSchedulers
+
+/**
+ * Specialized implementation of [Reactor] that ensures [state] Observables emits on [AndroidSchedulers.mainThread]
+ */
+class AndroidReactor<Action, Mutation, State>(initialState: State) : Reactor<Action, Mutation, State>(initialState) {
+    override fun transformAction(action: Observable<Action>): Observable<Action> = action.observeOn(AndroidSchedulers.mainThread())
+}

--- a/rxreactor2-android/src/main/java/com/gyurigrell/rxreactor2/android/AndroidReactor.kt
+++ b/rxreactor2-android/src/main/java/com/gyurigrell/rxreactor2/android/AndroidReactor.kt
@@ -8,5 +8,5 @@ import io.reactivex.android.schedulers.AndroidSchedulers
  * Specialized implementation of [Reactor] that ensures [state] Observables emits on [AndroidSchedulers.mainThread]
  */
 class AndroidReactor<Action, Mutation, State>(initialState: State) : Reactor<Action, Mutation, State>(initialState) {
-    override fun transformAction(action: Observable<Action>): Observable<Action> = action.observeOn(AndroidSchedulers.mainThread())
+    override fun transformState(state: Observable<State>): Observable<State> = state.observeOn(AndroidSchedulers.mainThread())
 }

--- a/rxreactor2-android/src/main/java/com/gyurigrell/rxreactor2/android/AndroidReactorWithEffect.kt
+++ b/rxreactor2-android/src/main/java/com/gyurigrell/rxreactor2/android/AndroidReactorWithEffect.kt
@@ -1,0 +1,17 @@
+package com.gyurigrell.rxreactor2.android
+
+import com.gyurigrell.rxreactor2.ReactorWithEffects
+import io.reactivex.Observable
+import io.reactivex.android.schedulers.AndroidSchedulers
+
+/**
+ * Specialized implementation of [ReactorWithEffects] that ensures [effect] and [state] Observables emit on
+ * [AndroidSchedulers.mainThread]
+ */
+class AndroidReactorWithEffect<Action, Mutation : ReactorWithEffects.MutationWithEffect<Effect>, State, Effect>(
+    initialState: State
+) : ReactorWithEffects<Action, Mutation, State, Effect>(initialState) {
+    override fun transformEffect(effect: Observable<Effect>): Observable<Effect> = effect.observeOn(AndroidSchedulers.mainThread())
+
+    override fun transformAction(action: Observable<Action>): Observable<Action> = action.observeOn(AndroidSchedulers.mainThread())
+}

--- a/rxreactor2-android/src/main/java/com/gyurigrell/rxreactor2/android/AndroidReactorWithEffect.kt
+++ b/rxreactor2-android/src/main/java/com/gyurigrell/rxreactor2/android/AndroidReactorWithEffect.kt
@@ -13,5 +13,5 @@ class AndroidReactorWithEffect<Action, Mutation : ReactorWithEffects.MutationWit
 ) : ReactorWithEffects<Action, Mutation, State, Effect>(initialState) {
     override fun transformEffect(effect: Observable<Effect>): Observable<Effect> = effect.observeOn(AndroidSchedulers.mainThread())
 
-    override fun transformAction(action: Observable<Action>): Observable<Action> = action.observeOn(AndroidSchedulers.mainThread())
+    override fun transformState(state: Observable<State>): Observable<State> = state.observeOn(AndroidSchedulers.mainThread())
 }


### PR DESCRIPTION
State changes and effects pretty much always need to be handled on Android main thread, so adding a set of base classes (`AndroidReactor` and `AndroidReactorWithEffects`) with overrides of `transformState` and `transformEffect` in order to `.observeOn(AndroidSchedulers.mainThread())`

Also bumping version to 0.3.2 for this addition