### PR TITLE
Added ability to clear all subscriptions in a reactor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,11 +68,10 @@ buildscript {
         ],
 
         'rx3'    : [
-            'java'   : 'io.reactivex.rxjava3:rxjava:3.0.3',
+            'java'   : 'io.reactivex.rxjava3:rxjava:3.0.4',
             'kotlin' : 'io.reactivex.rxjava3:rxkotlin:3.0.0',
             'android': 'io.reactivex.rxjava3:rxandroid:3.0.0',
-//            'relay' : 'com.jakewharton.rxrelay3:rxrelay:3.0.0',
-            'relay'  : 'com.github.JakeWharton:RxRelay:PR56-SNAPSHOT',
+            'relay' : 'com.jakewharton.rxrelay3:rxrelay:3.0.0',
         ]
     ]
 
@@ -94,9 +93,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { // TODO: Temporary until RxRelay releases version 3
-            url "https://jitpack.io"
-        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ task clean(type: Delete) {
 subprojects {
     group = "com.gyurigrell"
     def isRelease = Boolean.valueOf(project.hasProperty("release") ? project.property("release") as String : "false")
-    version = "0.4.1" + (isRelease ? "" : "-SNAPSHOT")
+    version = "0.4.5" + (isRelease ? "" : "-SNAPSHOT")
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
         kotlinOptions {

--- a/rxreactor1/src/main/kotlin/com/gyurigrell/rxreactor1/Reactor.kt
+++ b/rxreactor1/src/main/kotlin/com/gyurigrell/rxreactor1/Reactor.kt
@@ -43,7 +43,11 @@ abstract class Reactor<Action, Mutation, State>(
      */
     val state: Observable<State> by lazy { createStateStream() }
 
-    protected var disposables = CompositeSubscription()
+    /**
+     * Subscriptions in the reactor
+     */
+    @Suppress("MemberVisibilityCanBePrivate")
+    protected var subscriptions = CompositeSubscription()
 
     /**
      * Commits mutation from the action. This is the best place to perform side-effects such as async tasks.
@@ -76,6 +80,11 @@ abstract class Reactor<Action, Mutation, State>(
      */
     open fun transformState(state: Observable<State>): Observable<State> = state
 
+    /**
+     * Clear all subscriptions in the reactor. Only needs to be called if your reactor uses hot observables.
+     */
+    open fun clearSubscriptions() = subscriptions.clear()
+
     private fun createStateStream(): Observable<State> {
         val transformedAction = transformAction(action)
         val mutation = transformedAction.flatMap { action ->
@@ -88,6 +97,6 @@ abstract class Reactor<Action, Mutation, State>(
         val transformedState = transformState(state)
             .doOnNext { currentState = it }
             .replay(1)
-        return transformedState.apply { disposables.add(connect()) }
+        return transformedState.apply { subscriptions.add(connect()) }
     }
 }

--- a/rxreactor1/src/main/kotlin/com/gyurigrell/rxreactor1/ReactorView.kt
+++ b/rxreactor1/src/main/kotlin/com/gyurigrell/rxreactor1/ReactorView.kt
@@ -7,20 +7,21 @@
 
 package com.gyurigrell.rxreactor1
 
-import rx.subscriptions.CompositeSubscription
-
 /**
- * Do not let me check this in without adding a comment about the class.
+ * An optional interface to apply to your view which provides some formality around how to set up the reactor and the
+ * bindings between controls and state.
  */
 interface ReactorView<Action, Mutation, State> {
-    var disposeBag: CompositeSubscription
+    var reactor: Reactor<Action, Mutation, State>
 
-    var reactor: Reactor<Action, Mutation, State>?
-
-    fun bind(reactor: Reactor<Action, Mutation, State>)
+    fun bindControls(reactor: Reactor<Action, Mutation, State>)
+    fun bindState(reactor: Reactor<Action, Mutation, State>)
+    fun bindEffects(reactor: Reactor<Action, Mutation, State>)
 }
 
-fun <Action, Mutation, State> ReactorView<Action, Mutation, State>.attachReactor(reactor: Reactor<Action, Mutation, State>) {
+fun <Action, Mutation, State> ReactorView<Action, Mutation, State>.bind(reactor: Reactor<Action, Mutation, State>) {
     this.reactor = reactor
-    this.bind(reactor)
+    bindControls(reactor)
+    bindState(reactor)
+    bindEffects(reactor)
 }

--- a/rxreactor2/src/main/kotlin/com/gyurigrell/rxreactor2/Reactor.kt
+++ b/rxreactor2/src/main/kotlin/com/gyurigrell/rxreactor2/Reactor.kt
@@ -43,7 +43,11 @@ abstract class Reactor<Action, Mutation, State>(
      */
     val state: Observable<State> by lazy { createStateStream() }
 
-    protected var disposables = CompositeDisposable()
+    /**
+     * Subscriptions in the reactor
+     */
+    @Suppress("MemberVisibilityCanBePrivate")
+    protected var subscriptions = CompositeDisposable()
 
     /**
      * Commits mutation from the action. This is the best place to perform side-effects such as async tasks.
@@ -76,6 +80,11 @@ abstract class Reactor<Action, Mutation, State>(
      */
     open fun transformState(state: Observable<State>): Observable<State> = state
 
+    /**
+     * Clear all subscriptions in the reactor. Only needs to be called if your reactor uses hot observables.
+     */
+    open fun clearSubscriptions() = subscriptions.clear()
+
     private fun createStateStream(): Observable<State> {
         val transformedAction = transformAction(action)
         val mutation = transformedAction.flatMap { action ->
@@ -89,6 +98,6 @@ abstract class Reactor<Action, Mutation, State>(
         val transformedState = transformState(state)
             .doOnNext { currentState = it }
             .replay(1)
-        return transformedState.apply { disposables.add(connect()) }
+        return transformedState.apply { subscriptions.add(connect()) }
     }
 }

--- a/rxreactor2/src/main/kotlin/com/gyurigrell/rxreactor2/ReactorView.kt
+++ b/rxreactor2/src/main/kotlin/com/gyurigrell/rxreactor2/ReactorView.kt
@@ -7,20 +7,21 @@
 
 package com.gyurigrell.rxreactor2
 
-import io.reactivex.disposables.CompositeDisposable
-
 /**
- * Do not let me check this in without adding a comment about the class.
+ * An optional interface to apply to your view which provides some formality around how to set up the reactor and the
+ * bindings between controls and state.
  */
 interface ReactorView<Action, Mutation, State> {
-    var disposeBag: CompositeDisposable
+    var reactor: Reactor<Action, Mutation, State>
 
-    var reactor: Reactor<Action, Mutation, State>?
-
-    fun bind(reactor: Reactor<Action, Mutation, State>)
+    fun bindControls(reactor: Reactor<Action, Mutation, State>)
+    fun bindState(reactor: Reactor<Action, Mutation, State>)
+    fun bindEffects(reactor: Reactor<Action, Mutation, State>)
 }
 
-fun <Action, Mutation, State> ReactorView<Action, Mutation, State>.attachReactor(reactor: Reactor<Action, Mutation, State>) {
+fun <Action, Mutation, State> ReactorView<Action, Mutation, State>.bind(reactor: Reactor<Action, Mutation, State>) {
     this.reactor = reactor
-    this.bind(reactor)
+    bindControls(reactor)
+    bindState(reactor)
+    bindEffects(reactor)
 }

--- a/rxreactor3/src/main/java/com/gyurigrell/rxreactor3/Reactor.kt
+++ b/rxreactor3/src/main/java/com/gyurigrell/rxreactor3/Reactor.kt
@@ -46,7 +46,11 @@ abstract class Reactor<Action, Mutation, State>(
      */
     val state: Observable<State> by lazy { createStateStream() }
 
-    protected var disposables = CompositeDisposable()
+    /**
+     * Subscriptions in the reactor
+     */
+    @Suppress("MemberVisibilityCanBePrivate")
+    protected var subscriptions = CompositeDisposable()
 
     /**
      * Commits mutation from the action. This is the best place to perform side-effects such as async tasks.
@@ -79,6 +83,11 @@ abstract class Reactor<Action, Mutation, State>(
      */
     open fun transformState(state: Observable<State>): Observable<State> = state
 
+    /**
+     * Clear all subscriptions in the reactor. Only needs to be called if your reactor uses hot observables.
+     */
+    open fun clearSubscriptions() = subscriptions.clear()
+
     private fun createStateStream(): Observable<State> {
         val transformedAction = transformAction(action)
         val mutation = transformedAction.flatMap { action ->
@@ -92,6 +101,6 @@ abstract class Reactor<Action, Mutation, State>(
         val transformedState = transformState(state)
             .doOnNext { currentState = it }
             .replay(1)
-        return transformedState.apply { disposables.add(connect()) }
+        return transformedState.apply { subscriptions.add(connect()) }
     }
 }

--- a/rxreactor3/src/main/java/com/gyurigrell/rxreactor3/ReactorView.kt
+++ b/rxreactor3/src/main/java/com/gyurigrell/rxreactor3/ReactorView.kt
@@ -7,20 +7,21 @@
 
 package com.gyurigrell.rxreactor3
 
-import io.reactivex.rxjava3.disposables.CompositeDisposable
-
 /**
- * Do not let me check this in without adding a comment about the class.
+ * An optional interface to apply to your view which provides some formality around how to set up the reactor and the
+ * bindings between controls and state.
  */
 interface ReactorView<Action, Mutation, State> {
-    var disposeBag: CompositeDisposable
+    var reactor: Reactor<Action, Mutation, State>
 
-    var reactor: Reactor<Action, Mutation, State>?
-
-    fun bind(reactor: Reactor<Action, Mutation, State>)
+    fun bindControls(reactor: Reactor<Action, Mutation, State>)
+    fun bindState(reactor: Reactor<Action, Mutation, State>)
+    fun bindEffects(reactor: Reactor<Action, Mutation, State>)
 }
 
-fun <Action, Mutation, State> ReactorView<Action, Mutation, State>.attachReactor(reactor: Reactor<Action, Mutation, State>) {
+fun <Action, Mutation, State> ReactorView<Action, Mutation, State>.bind(reactor: Reactor<Action, Mutation, State>) {
     this.reactor = reactor
-    this.bind(reactor)
+    bindControls(reactor)
+    bindState(reactor)
+    bindEffects(reactor)
 }

--- a/sample/src/main/java/com/gyurigrell/rxreactor2/sample/LoginReactorProvider.kt
+++ b/sample/src/main/java/com/gyurigrell/rxreactor2/sample/LoginReactorProvider.kt
@@ -16,6 +16,10 @@ class LoginReactorProvider private constructor(private val contactService: Conta
         get() = LoginReactor(contactService, initialState
             ?: LoginReactor.State())
 
+    override fun onCleared() {
+        reactor.clearSubscriptions()
+    }
+
     class Factory(private val contactService: ContactService): ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T = LoginReactorProvider(contactService) as T


### PR DESCRIPTION
* Ran into an issue where a hot subscription used in a reactor instance would not get disposed, and thus the state subscription would not shut down. Added a `Reactor.clearSubscriptions()` to handle this case.
* Refactored `ReactorView` to be a bit simpler.