### PR TITLE
Removing ReactorWithEffects.MutationWithEffect

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext.siteUrl = "https://github.com/ggrell/RxReactor"
+    ext.gitUrl = "https://github.com/ggrell/RxReactor.git"
+
     ext.buildConfig = [
         minSdk    : 15,
         compileSdk: 29,
@@ -74,10 +77,9 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.3'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$versions.dokka"
     }
 }
@@ -96,7 +98,7 @@ task clean(type: Delete) {
 subprojects {
     group = "com.gyurigrell"
     def isRelease = Boolean.valueOf(project.hasProperty("release") ? project.property("release") as String : "false")
-    version = "0.4.6" + (isRelease ? "" : "-SNAPSHOT")
+    version = "0.9.0" + (isRelease ? "" : "-SNAPSHOT")
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
         kotlinOptions {

--- a/gradle/library-artifacts.gradle
+++ b/gradle/library-artifacts.gradle
@@ -5,47 +5,6 @@ if (project.plugins.hasPlugin('com.android.library')) {
         }
     }
 
-    def siteUrl = "https://github.com/ggrell/RxReactor"
-    def gitUrl = "https://github.com/ggrell/RxReactor.git"
-
-    install {
-        repositories {
-            mavenInstaller {
-                pom {
-                    project {
-                        packaging 'aar'
-
-                        groupId project.group
-                        artifactId archivesBaseName
-
-                        url siteUrl
-
-                        licenses {
-                            license {
-                                name 'BSD 3-Clause License'
-                                url 'https://github.com/ggrell/RxReactor/blob/master/LICENSE'
-                            }
-                        }
-
-                        developers {
-                            developer {
-                                id 'ggrell'
-                                name 'Gyuri Grell'
-                                email 'ggrell@pobox.com'
-                            }
-                        }
-
-                        scm {
-                            connection gitUrl
-                            developerConnection gitUrl
-                            url siteUrl
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     afterEvaluate {
         task sourcesJar(type: Jar) {
             classifier 'sources'
@@ -55,11 +14,6 @@ if (project.plugins.hasPlugin('com.android.library')) {
         task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
             classifier 'javadoc'
             from dokkaJavadoc.outputDirectory
-        }
-
-        artifacts {
-            archives sourcesJar
-            archives javadocJar
         }
     }
 }

--- a/rxreactor1-android/build.gradle
+++ b/rxreactor1-android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'jacoco'
 apply plugin: 'org.jetbrains.dokka'
-apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'maven-publish'
 apply from: "$rootDir/gradle/library-artifacts.gradle"
 apply from: "$rootDir/gradle/jacoco-android.gradle"
 
@@ -58,4 +58,46 @@ tasks.withType(Test) {
 
 jacoco {
     toolVersion = versions.jacoco
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            rxreactor1Android(MavenPublication) {
+                groupId = project.group
+                artifactId = archivesBaseName
+
+                from components.release
+                artifact sourcesJar
+                artifact javadocJar
+
+                pom {
+                    name = "RxReactor (RxJava 1) for Android"
+                    description = "A Kotlin framework for a reactive and unidirectional RxJava 1 application architecture"
+                    url = siteUrl
+
+                    licenses {
+                        license {
+                            name = 'BSD 3-Clause License'
+                            url = 'https://github.com/ggrell/RxReactor/blob/master/LICENSE'
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id = 'ggrell'
+                            name = 'Gyuri Grell'
+                            email = 'ggrell@pobox.com'
+                        }
+                    }
+
+                    scm {
+                        connection = gitUrl
+                        developerConnection = gitUrl
+                        url = siteUrl
+                    }
+                }
+            }
+        }
+    }
 }

--- a/rxreactor1/build.gradle
+++ b/rxreactor1/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin'
 apply plugin: 'jacoco'
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'com.github.kt3k.coveralls'
-apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'maven-publish'
 
 dependencies {
     implementation deps.kotlin.stdlib.jdk
@@ -33,7 +33,42 @@ task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
     from dokkaJavadoc.outputDirectory
 }
 
-artifacts {
-    archives sourcesJar
-    archives javadocJar
+publishing {
+    publications {
+        rxreactor2(MavenPublication) {
+            groupId = project.group
+            artifactId = archivesBaseName
+
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+
+            pom {
+                name = "RxReactor (RxJava 1)"
+                description = "A Kotlin framework for a reactive and unidirectional RxJava 1 application architecture"
+                url = siteUrl
+
+                licenses {
+                    license {
+                        name = 'BSD 3-Clause License'
+                        url = 'https://github.com/ggrell/RxReactor/blob/master/LICENSE'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'ggrell'
+                        name = 'Gyuri Grell'
+                        email = 'ggrell@pobox.com'
+                    }
+                }
+
+                scm {
+                    connection = gitUrl
+                    developerConnection = gitUrl
+                    url = siteUrl
+                }
+            }
+        }
+    }
 }

--- a/rxreactor1/src/main/kotlin/com/gyurigrell/rxreactor1/ReactorView.kt
+++ b/rxreactor1/src/main/kotlin/com/gyurigrell/rxreactor1/ReactorView.kt
@@ -11,17 +11,16 @@ package com.gyurigrell.rxreactor1
  * An optional interface to apply to your view which provides some formality around how to set up the reactor and the
  * bindings between controls and state.
  */
-interface ReactorView<Action, Mutation, State> {
-    var reactor: Reactor<Action, Mutation, State>
+@Deprecated("This will be removed in 1.0")
+interface ReactorView {
+    var reactor: Reactor<*, *, *>
 
-    fun bindControls(reactor: Reactor<Action, Mutation, State>)
-    fun bindState(reactor: Reactor<Action, Mutation, State>)
-    fun bindEffects(reactor: Reactor<Action, Mutation, State>)
+    fun <Action, Mutation, State> bindViews(reactor: Reactor<Action, Mutation, State>)
+    fun <Action, Mutation, State> bindState(reactor: Reactor<Action, Mutation, State>)
 }
 
-fun <Action, Mutation, State> ReactorView<Action, Mutation, State>.bind(reactor: Reactor<Action, Mutation, State>) {
+fun <Action, Mutation, State> ReactorView.bind(reactor: Reactor<Action, Mutation, State>) {
     this.reactor = reactor
-    bindControls(reactor)
+    bindViews(reactor)
     bindState(reactor)
-    bindEffects(reactor)
 }

--- a/rxreactor2-android/build.gradle
+++ b/rxreactor2-android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'jacoco'
 apply plugin: 'org.jetbrains.dokka'
-apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'maven-publish'
 apply from: "$rootDir/gradle/library-artifacts.gradle"
 apply from: "$rootDir/gradle/jacoco-android.gradle"
 
@@ -58,4 +58,46 @@ tasks.withType(Test) {
 
 jacoco {
     toolVersion = versions.jacoco
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            rxreactor2Android(MavenPublication) {
+                groupId = project.group
+                artifactId = archivesBaseName
+
+                from components.release
+                artifact sourcesJar
+                artifact javadocJar
+
+                pom {
+                    name = "RxReactor (RxJava 2) for Android"
+                    description = "A Kotlin framework for a reactive and unidirectional RxJava 2 application architecture"
+                    url = siteUrl
+
+                    licenses {
+                        license {
+                            name = 'BSD 3-Clause License'
+                            url = 'https://github.com/ggrell/RxReactor/blob/master/LICENSE'
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id = 'ggrell'
+                            name = 'Gyuri Grell'
+                            email = 'ggrell@pobox.com'
+                        }
+                    }
+
+                    scm {
+                        connection = gitUrl
+                        developerConnection = gitUrl
+                        url = siteUrl
+                    }
+                }
+            }
+        }
+    }
 }

--- a/rxreactor2/build.gradle
+++ b/rxreactor2/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin'
 apply plugin: 'jacoco'
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'com.github.kt3k.coveralls'
-apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'maven-publish'
 
 dependencies {
     implementation deps.kotlin.stdlib.jdk
@@ -33,7 +33,42 @@ task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
     from dokkaJavadoc.outputDirectory
 }
 
-artifacts {
-    archives sourcesJar
-    archives javadocJar
+publishing {
+    publications {
+        rxreactor1(MavenPublication) {
+            groupId = project.group
+            artifactId = archivesBaseName
+
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+
+            pom {
+                name = "RxReactor (RxJava 2)"
+                description = "A Kotlin framework for a reactive and unidirectional RxJava 2 application architecture"
+                url = siteUrl
+
+                licenses {
+                    license {
+                        name = 'BSD 3-Clause License'
+                        url = 'https://github.com/ggrell/RxReactor/blob/master/LICENSE'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'ggrell'
+                        name = 'Gyuri Grell'
+                        email = 'ggrell@pobox.com'
+                    }
+                }
+
+                scm {
+                    connection = gitUrl
+                    developerConnection = gitUrl
+                    url = siteUrl
+                }
+            }
+        }
+    }
 }

--- a/rxreactor2/src/main/kotlin/com/gyurigrell/rxreactor2/ReactorView.kt
+++ b/rxreactor2/src/main/kotlin/com/gyurigrell/rxreactor2/ReactorView.kt
@@ -11,6 +11,7 @@ package com.gyurigrell.rxreactor2
  * An optional interface to apply to your view which provides some formality around how to set up the reactor and the
  * bindings between controls and state.
  */
+@Deprecated("This will be removed in 1.0")
 interface ReactorView<Action, Mutation, State> {
     var reactor: Reactor<Action, Mutation, State>
 

--- a/rxreactor2/src/main/kotlin/com/gyurigrell/rxreactor2/ReactorWithEffects.kt
+++ b/rxreactor2/src/main/kotlin/com/gyurigrell/rxreactor2/ReactorWithEffects.kt
@@ -56,18 +56,28 @@ abstract class ReactorWithEffects<Action, Mutation : MutationWithEffect<Effect>,
     open fun transformEffect(effect: Observable<Effect>): Observable<Effect> = effect
 
     /**
+     * Emits all effects provided by the Observable
+     * @param effect tan Observable that emits effects
+     */
+    protected fun emitEffect(effect: Observable<Effect>) {
+        effect.subscribe(effectRelay).also { subscriptions.add(it) }
+    }
+
+    /**
+     * Simplified way to emits effects
+     * @param effect one or more Effects to be emitted
+     */
+    protected fun emitEffect(vararg effect: Effect) {
+        Observable.fromIterable(effect.asIterable()).subscribe(effectRelay).also { subscriptions.add(it) }
+    }
+
+    /**
      * The interface that needs to be applied to the [Mutation] sealed class defined in this [ReactorWithEffects]. It
      * applies a field named [effect] which defaults to `null`, meaning that mutation doesn't emit effects. Generally
      * there should only be a single mutation that has an override where it provides an effect.
      * @param Effect this is just the [Effect] type defined in the reactor.
-     * ```
-     *     sealed class Mutation: MutationWithEffect<Effect> {
-     *         object Mutation1 : Mutation()
-     *         data class Mutation2(val someValue): Mutation()
-     *         data class EmitEffect(override val effect: Effect): Mutation()
-     *     }
-     *  ```
      */
+    @Deprecated("Prefer calling `emitEffect()` function instead")
     interface MutationWithEffect<Effect> {
         val effect: Effect?
             get() = null

--- a/rxreactor3-android/build.gradle
+++ b/rxreactor3-android/build.gradle
@@ -1,7 +1,8 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'jacoco'
 apply plugin: 'org.jetbrains.dokka'
-apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'maven-publish'
 apply from: "$rootDir/gradle/library-artifacts.gradle"
 apply from: "$rootDir/gradle/jacoco-android.gradle"
 
@@ -49,4 +50,54 @@ dependencies {
 
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+}
+
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+}
+
+jacoco {
+    toolVersion = versions.jacoco
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            rxreactor3Android(MavenPublication) {
+                groupId = project.group
+                artifactId = archivesBaseName
+
+                from components.release
+                artifact sourcesJar
+                artifact javadocJar
+
+                pom {
+                    name = "RxReactor (RxJava 3) for Android"
+                    description = "A Kotlin framework for a reactive and unidirectional RxJava 3 application architecture"
+                    url = siteUrl
+
+                    licenses {
+                        license {
+                            name = 'BSD 3-Clause License'
+                            url = 'https://github.com/ggrell/RxReactor/blob/master/LICENSE'
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id = 'ggrell'
+                            name = 'Gyuri Grell'
+                            email = 'ggrell@pobox.com'
+                        }
+                    }
+
+                    scm {
+                        connection = gitUrl
+                        developerConnection = gitUrl
+                        url = siteUrl
+                    }
+                }
+            }
+        }
+    }
 }

--- a/rxreactor3/build.gradle
+++ b/rxreactor3/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin'
 apply plugin: 'jacoco'
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'com.github.kt3k.coveralls'
-apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'maven-publish'
 
 dependencies {
     implementation deps.kotlin.stdlib.jdk
@@ -33,7 +33,42 @@ task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
     from dokkaJavadoc.outputDirectory
 }
 
-artifacts {
-    archives sourcesJar
-    archives javadocJar
+publishing {
+    publications {
+        rxreactor3(MavenPublication) {
+            groupId = project.group
+            artifactId = archivesBaseName
+
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+
+            pom {
+                name = "RxReactor (RxJava 3)"
+                description = "A Kotlin framework for a reactive and unidirectional RxJava 3 application architecture"
+                url = siteUrl
+
+                licenses {
+                    license {
+                        name = 'BSD 3-Clause License'
+                        url = 'https://github.com/ggrell/RxReactor/blob/master/LICENSE'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'ggrell'
+                        name = 'Gyuri Grell'
+                        email = 'ggrell@pobox.com'
+                    }
+                }
+
+                scm {
+                    connection = gitUrl
+                    developerConnection = gitUrl
+                    url = siteUrl
+                }
+            }
+        }
+    }
 }

--- a/rxreactor3/src/main/java/com/gyurigrell/rxreactor3/ReactorView.kt
+++ b/rxreactor3/src/main/java/com/gyurigrell/rxreactor3/ReactorView.kt
@@ -11,6 +11,7 @@ package com.gyurigrell.rxreactor3
  * An optional interface to apply to your view which provides some formality around how to set up the reactor and the
  * bindings between controls and state.
  */
+@Deprecated("This will be removed in 1.0")
 interface ReactorView<Action, Mutation, State> {
     var reactor: Reactor<Action, Mutation, State>
 

--- a/rxreactor3/src/main/java/com/gyurigrell/rxreactor3/ReactorWithEffects.kt
+++ b/rxreactor3/src/main/java/com/gyurigrell/rxreactor3/ReactorWithEffects.kt
@@ -56,18 +56,28 @@ abstract class ReactorWithEffects<Action, Mutation : MutationWithEffect<Effect>,
     open fun transformEffect(effect: Observable<Effect>): Observable<Effect> = effect
 
     /**
+     * Emits all effects provided by the Observable
+     * @param effect tan Observable that emits effects
+     */
+    protected fun emitEffect(effect: Observable<Effect>) {
+        effect.subscribe(effectRelay).also { subscriptions.add(it) }
+    }
+
+    /**
+     * Simplified way to emits effects
+     * @param effect one or more Effects to be emitted
+     */
+    protected fun emitEffect(vararg effect: Effect) {
+        Observable.fromIterable(effect.asIterable()).subscribe(effectRelay).also { subscriptions.add(it) }
+    }
+
+    /**
      * The interface that needs to be applied to the [Mutation] sealed class defined in this [ReactorWithEffects]. It
      * applies a field named [effect] which defaults to `null`, meaning that mutation doesn't emit effects. Generally
      * there should only be a single mutation that has an override where it provides an effect.
      * @param Effect this is just the [Effect] type defined in the reactor.
-     * ```
-     *     sealed class Mutation: MutationWithEffect<Effect> {
-     *         object Mutation1 : Mutation()
-     *         data class Mutation2(val someValue): Mutation()
-     *         data class EmitEffect(override val effect: Effect): Mutation()
-     *     }
-     *  ```
      */
+    @Deprecated("Prefer calling `emitEffect()` function instead")
     interface MutationWithEffect<Effect> {
         val effect: Effect?
             get() = null

--- a/rxreactor3/src/test/java/com/gyurigrell/rxreactor3/ReactorWithEffectsTests.kt
+++ b/rxreactor3/src/test/java/com/gyurigrell/rxreactor3/ReactorWithEffectsTests.kt
@@ -10,6 +10,7 @@ package com.gyurigrell.rxreactor3
 import com.gyurigrell.rxreactor3.ReactorWithEffectsTests.TestReactor.*
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.observers.TestObserver
+
 import org.junit.Test
 
 /**
@@ -27,9 +28,8 @@ class ReactorWithEffectsTests {
         reactor.action.accept(Action.SimpleAction)
 
         // Assert
-        states
-            .assertNoErrors()
-            .assertValues(State(false), State(true))
+        states.assertNoErrors()
+        states.assertValues(State(false), State(true))
     }
 
     @Test
@@ -44,9 +44,8 @@ class ReactorWithEffectsTests {
         reactor.action.accept(Action.ActionWithValue(theValue))
 
         // Assert
-        states
-            .assertNoErrors()
-            .assertValues(State(), State(false, theValue))
+        states.assertNoErrors()
+        states.assertValues(State(), State(false, theValue))
     }
 
     @Test
@@ -62,12 +61,10 @@ class ReactorWithEffectsTests {
         reactor.action.accept(Action.ActionFiresEffectOne)
 
         // Assert
-        states
-            .assertNoErrors()
-            .assertValues(State())
-        effects
-            .assertNoErrors()
-            .assertValues(Effect.EffectOne)
+        states.assertNoErrors()
+        states.assertValue(State())
+        effects.assertNoErrors()
+        effects.assertValue(Effect.EffectOne)
     }
 
     @Test
@@ -84,15 +81,13 @@ class ReactorWithEffectsTests {
         reactor.action.accept(Action.ActionFiresEffectWithValue(theValue))
 
         // Assert
-        states
-            .assertNoErrors()
-            .assertValues(State())
-        effects
-            .assertNoErrors()
-            .assertValues(Effect.EffectWithValue(theValue))
+        states.assertNoErrors()
+        states.assertValue(State())
+        effects.assertNoErrors()
+        effects.assertValue(Effect.EffectWithValue(theValue))
     }
 
-    class TestReactor(
+    private class TestReactor(
         initialState: State = State()
     ) : ReactorWithEffects<Action, Mutation, State, Effect>(initialState) {
         sealed class Action {
@@ -105,7 +100,6 @@ class ReactorWithEffectsTests {
         sealed class Mutation : MutationWithEffect<Effect> {
             object SimpleActionMutation : Mutation()
             data class ActionWithValueMutation(val theValue: String) : Mutation()
-            data class FireEffect(override val effect: Effect) : Mutation()
         }
 
         data class State(
@@ -119,22 +113,27 @@ class ReactorWithEffectsTests {
         }
 
         override fun mutate(action: Action): Observable<Mutation> = when (action) {
-            is Action.SimpleAction -> Observable.just(Mutation.SimpleActionMutation)
+            is Action.SimpleAction ->
+                Observable.just(Mutation.SimpleActionMutation)
 
-            is Action.ActionWithValue -> Observable.just(Mutation.ActionWithValueMutation(action.theValue))
+            is Action.ActionWithValue ->
+                Observable.just(Mutation.ActionWithValueMutation(action.theValue))
 
-            is Action.ActionFiresEffectOne -> Observable.just(Mutation.FireEffect(Effect.EffectOne))
+            is Action.ActionFiresEffectOne -> {
+                emitEffect(Effect.EffectOne)
+                Observable.empty() // No mutations
+            }
 
-            is Action.ActionFiresEffectWithValue ->
-                Observable.just(Mutation.FireEffect(Effect.EffectWithValue(action.theValue)))
+            is Action.ActionFiresEffectWithValue -> {
+                emitEffect(Effect.EffectWithValue(action.theValue))
+                Observable.empty() // No mutations
+            }
         }
 
         override fun reduce(state: State, mutation: Mutation): State = when (mutation) {
             is Mutation.SimpleActionMutation -> state.copy(simpleAction = true)
 
             is Mutation.ActionWithValueMutation -> state.copy(actionWithValue = mutation.theValue)
-
-            is Mutation.FireEffect -> state // This will never happen, but need to be exhaustive
         }
     }
 }

--- a/rxreactor3/src/test/java/com/gyurigrell/rxreactor3/ReactorWithMutationEffectsTests.kt
+++ b/rxreactor3/src/test/java/com/gyurigrell/rxreactor3/ReactorWithMutationEffectsTests.kt
@@ -5,89 +5,94 @@
  * https://opensource.org/licenses/BSD-3-Clause
  */
 
-package com.gyurigrell.rxreactor1
+package com.gyurigrell.rxreactor3
 
-import com.gyurigrell.rxreactor1.ReactorWithEffectsTests.TestReactor.*
-
+import com.gyurigrell.rxreactor3.ReactorWithMutationEffectsTests.TestReactor.*
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.observers.TestObserver
 import org.junit.Test
-import rx.Observable
-import rx.observers.TestSubscriber
 
 /**
  * Unit tests for [ReactorWithEffects]
  */
-class ReactorWithEffectsTests {
+class ReactorWithMutationEffectsTests {
     @Test
     fun `SimpleAction updates State simpleAction to true`() {
         // Arrange
         val reactor = TestReactor()
-        val states = TestSubscriber.create<State>()
+        val states = TestObserver.create<State>()
         reactor.state.subscribe(states)
 
         // Act
-        reactor.action.call(Action.SimpleAction)
+        reactor.action.accept(Action.SimpleAction)
 
         // Assert
-        states.assertNoErrors()
-        states.assertValues(State(false), State(true))
+        states
+            .assertNoErrors()
+            .assertValues(State(false), State(true))
     }
 
     @Test
     fun `ActionWithValue updates State actionWithValue to correct string`() {
         // Arrange
         val reactor = TestReactor()
-        val states = TestSubscriber.create<State>()
+        val states = TestObserver.create<State>()
         reactor.state.subscribe(states)
         val theValue = "I love apple pie"
 
         // Act
-        reactor.action.call(Action.ActionWithValue(theValue))
+        reactor.action.accept(Action.ActionWithValue(theValue))
 
         // Assert
-        states.assertNoErrors()
-        states.assertValues(State(), State(false, theValue))
+        states
+            .assertNoErrors()
+            .assertValues(State(), State(false, theValue))
     }
 
     @Test
     fun `ActionFiresEffectOne emits the effect `() {
         // Arrange
         val reactor = TestReactor()
-        val states = TestSubscriber.create<State>()
-        val effects = TestSubscriber.create<Effect>()
+        val states = TestObserver.create<State>()
+        val effects = TestObserver.create<Effect>()
         reactor.state.subscribe(states)
         reactor.effect.subscribe(effects)
 
         // Act
-        reactor.action.call(Action.ActionFiresEffectOne)
+        reactor.action.accept(Action.ActionFiresEffectOne)
 
         // Assert
-        states.assertNoErrors()
-        states.assertValue(State())
-        effects.assertNoErrors()
-        effects.assertValue(Effect.EffectOne)
+        states
+            .assertNoErrors()
+            .assertValues(State())
+        effects
+            .assertNoErrors()
+            .assertValues(Effect.EffectOne)
     }
 
     @Test
     fun `ActionFiresEffectWithValue emits the effect with the correct value`() {
         // Arrange
         val reactor = TestReactor()
-        val states = TestSubscriber.create<State>()
-        val effects = TestSubscriber.create<Effect>()
+        val states = TestObserver.create<State>()
+        val effects = TestObserver.create<Effect>()
         reactor.state.subscribe(states)
         reactor.effect.subscribe(effects)
         val theValue = "Millions of peaches, peaches for me"
 
         // Act
-        reactor.action.call(Action.ActionFiresEffectWithValue(theValue))
+        reactor.action.accept(Action.ActionFiresEffectWithValue(theValue))
 
         // Assert
-        states.assertNoErrors()
-        states.assertValue(State())
-        effects.assertNoErrors()
-        effects.assertValue(Effect.EffectWithValue(theValue))
+        states
+            .assertNoErrors()
+            .assertValues(State())
+        effects
+            .assertNoErrors()
+            .assertValues(Effect.EffectWithValue(theValue))
     }
 
-    private class TestReactor(
+    class TestReactor(
         initialState: State = State()
     ) : ReactorWithEffects<Action, Mutation, State, Effect>(initialState) {
         sealed class Action {
@@ -100,6 +105,7 @@ class ReactorWithEffectsTests {
         sealed class Mutation : MutationWithEffect<Effect> {
             object SimpleActionMutation : Mutation()
             data class ActionWithValueMutation(val theValue: String) : Mutation()
+            data class FireEffect(override val effect: Effect) : Mutation()
         }
 
         data class State(
@@ -113,27 +119,22 @@ class ReactorWithEffectsTests {
         }
 
         override fun mutate(action: Action): Observable<Mutation> = when (action) {
-            is Action.SimpleAction ->
-                Observable.just(Mutation.SimpleActionMutation)
+            is Action.SimpleAction -> Observable.just(Mutation.SimpleActionMutation)
 
-            is Action.ActionWithValue ->
-                Observable.just(Mutation.ActionWithValueMutation(action.theValue))
+            is Action.ActionWithValue -> Observable.just(Mutation.ActionWithValueMutation(action.theValue))
 
-            is Action.ActionFiresEffectOne -> {
-                emitEffect(Effect.EffectOne)
-                Observable.empty() // No mutations
-            }
+            is Action.ActionFiresEffectOne -> Observable.just(Mutation.FireEffect(Effect.EffectOne))
 
-            is Action.ActionFiresEffectWithValue -> {
-                emitEffect(Effect.EffectWithValue(action.theValue))
-                Observable.empty() // No mutations
-            }
+            is Action.ActionFiresEffectWithValue ->
+                Observable.just(Mutation.FireEffect(Effect.EffectWithValue(action.theValue)))
         }
 
         override fun reduce(state: State, mutation: Mutation): State = when (mutation) {
             is Mutation.SimpleActionMutation -> state.copy(simpleAction = true)
 
             is Mutation.ActionWithValueMutation -> state.copy(actionWithValue = mutation.theValue)
+
+            is Mutation.FireEffect -> state // This will never happen, but need to be exhaustive
         }
     }
 }


### PR DESCRIPTION
## CHANGES
* This implementation was modeled on what we needed to make effects work on ReactorKit, but emitting effects directly is much cleaner implementation. Marked `MutationWithEffect` deprecated, to be removed by 1.0
* Upgraded to maven-publish plugin (facilitated in local deploys and testing)