### PR TITLE
Fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Releases are published to Maven Central, and individual archives are also availa
 
 ```groovy
 subprojects {
-    repositiories {
+    repositories {
         mavenCentral()
     }
 }
@@ -27,7 +27,7 @@ subprojects {
 Add this repository to have access to Maven Central snapshots:
 ```groovy
 subprojects {
-    repositiories {
+    repositories {
         maven {
             url 'https://oss.sonatype.org/content/repositories/snapshots/'
             mavenContent { snapshotsOnly() }


### PR DESCRIPTION
## Summary
- correct spelling of `repositories` in Groovy snippets

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc5aed940832298b1970f51892b6f